### PR TITLE
Bump @kidonng/vuepress-plugin-contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "vuepress-plugin-mermaidjs": "^1.5.1"
   },
   "dependencies": {
-    "@kidonng/vuepress-plugin-contributors": "^0.2.0",
+    "@kidonng/vuepress-plugin-contributors": "^0.3.0",
     "uuid": "^8.3.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -891,10 +891,10 @@
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-3.1.0.tgz#8ff71d51053cd5ee4981e5a501d80a536244f7fd"
   integrity sha512-GcIY79elgB+azP74j8vqkiXz8xLFfIzbQJdlwOPisgbKT00tviJQuEghOXSMVxJ00HoYJbGswr4kcllUc4xCcg==
 
-"@kidonng/vuepress-plugin-contributors@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@kidonng/vuepress-plugin-contributors/-/vuepress-plugin-contributors-0.2.0.tgz#447265f8e2f65a600655160ffc7d244cc88fab5b"
-  integrity sha512-VhM2EdK7N/83fe6M0R1mYNYEnifNWRZMqEsv8iKzMjUopRinFoywbd3U4ybR6HzRI+m3smM5/zoLvwqu34WdSw==
+"@kidonng/vuepress-plugin-contributors@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@kidonng/vuepress-plugin-contributors/-/vuepress-plugin-contributors-0.3.0.tgz#5da0b0e11865e5c87ceed259f9781d7a50226188"
+  integrity sha512-9Kz/+/DW/2OheM+hhITfw54yQ8escWpNK0SnT7BCLD+l4mJ79+GWlV8bVI070CGa+6GspptkjVEUXt5ZNFPKbg==
   dependencies:
     ky "^0.24.0"
 


### PR DESCRIPTION
Hello, `@kidonng/vuepress-plugin-contributors` recently [changed its API endpoint](https://github.com/kidonng/vuepress-plugin-contributors/releases/tag/v0.3.0), please upgrade to a new version in order for it to function.